### PR TITLE
MVVMの検索周りを修正

### DIFF
--- a/07/RxMVVMSample/RxMVVMSample/SearchUser/SearchUserModel.swift
+++ b/07/RxMVVMSample/RxMVVMSample/SearchUser/SearchUserModel.swift
@@ -4,22 +4,29 @@
 //
 
 import GitHub
+import RxSwift
 
 protocol SearchUserModelProtocol {
-    func fetchUser(query: String, completion: @escaping (Result<[User]>) -> ())
+    func fetchUser(query: String) -> Observable<[User]>
 }
 
-class SearchUserModel: SearchUserModelProtocol {
-    func fetchUser(query: String, completion: @escaping (Result<[User]
-    >) -> ()) {
-        let session = Session()
-        let request = SearchUsersRequest(query: query, sort: nil, order: nil, page: nil, perPage: nil)
-        session.send(request) { result in
-            switch result {
-            case .success(let response):
-                completion(.success(response.0.items))
-            case .failure(let error):
-                completion(.failure(error))
+final class SearchUserModel: SearchUserModelProtocol {
+    let session = Session()
+
+    func fetchUser(query: String) -> Observable<[User]> {
+        return Observable.create { [weak self] observer in
+            let request = SearchUsersRequest(query: query, sort: nil, order: nil, page: nil, perPage: nil)
+            let task = self?.session.send(request) { result in
+                switch result {
+                case .success(let response):
+                    observer.onNext(response.0.items)
+                    observer.onCompleted()
+                case .failure(let error):
+                    observer.onError(error)
+                }
+            }
+            return Disposables.create {
+                task?.cancel()
             }
         }
     }


### PR DESCRIPTION
- SearchUserModelProtocolをRx対応
- SearchUserViewModelをlazy varにして非Optional化
- BehaviorRelayをViewModel内に隠蔽
- ViewModelにObserverを渡すのではなく、ViewModelから生えているObservableからbindするように修正