### PR TITLE
14章までのXcode12対応でテストが失敗していた箇所の修正

### DIFF
--- a/14/FluxPlusExample/FluxPlusExampleTests/Tests/View/RepositorySearchViewControllerTests.swift
+++ b/14/FluxPlusExample/FluxPlusExampleTests/Tests/View/RepositorySearchViewControllerTests.swift
@@ -57,6 +57,7 @@ final class RepositorySearchViewControllerTests: XCTestCase {
             })
 
         let searchBar: UISearchBar = dependency.viewController.searchBar
+        searchBar.text = query
         searchBar.delegate!.searchBar!(searchBar, textDidChange: query)
         searchBar.delegate!.searchBarSearchButtonClicked!(searchBar)
 


### PR DESCRIPTION
#16 で失敗しているテストの修正となります

## RxSimpleSampleのtest_changeTextAndColorの失敗理由

- ViewModel内の`skip(1)`の実装が考慮されていないテストになっていた
- ViewModelのinitializerから受け取っていたinputから値を変換してshareする処理がされていたが、初期化後に即値で流れてくる想定になっていないテストだった

## FluxPlusExampleのtestSearchButtonClickedの失敗理由

RxSwift **v4.3.1**時点ではUISearchBar.rx.textの実装でmethodInvokedの引数を利用していたが、RxSwift **v6.0.0**時点の実装ではmethodInvokedの引数を利用せずに`UISearchBar.text`の値を流す実装となっていたため、UISearchBar.delegate経由でUISearchBar.rx.textを発火させた場合にUISearchBar.textに値を代入する必要があった

v4.3.1のUISearchBar.rx.text
https://github.com/ReactiveX/RxSwift/blob/0df62b4d562f8620d4b795b18e4adf0b631527a1/RxCocoa/iOS/UISearchBar%2BRx.swift#L29-L45

v6.0.0のUISearchBar.rx.text
https://github.com/ReactiveX/RxSwift/blob/7e01c05f25c025143073eaa3be3532f9375c614b/RxCocoa/iOS/UISearchBar%2BRx.swift#L29-L46